### PR TITLE
Fix scheme parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ impl UrlLocator {
     #[inline]
     fn advance_scheme(&mut self, state: SchemeState, c: char) -> UrlLocation {
         self.state = match state.advance(c) {
-            SchemeState::NONE => return self.reset(),
+            SchemeState::RESET => return self.reset(),
             SchemeState::COMPLETE => State::Url,
             state => State::Scheme(state),
         };

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -7,13 +7,14 @@ macro_rules! schemes {
         pub enum $name {
             $($result,)*
             COMPLETE,
-            NONE,
+            INVALID,
+            RESET,
         }
 
         impl Default for $name {
             #[inline]
             fn default() -> Self {
-                $name::NONE
+                $name::RESET
             }
         }
 
@@ -23,7 +24,8 @@ macro_rules! schemes {
                 match (self, c) {
                     $($(($name::$state, $match))|+ => $name::$result,)*
                     $(($name::$complete, ':') => $name::COMPLETE,)*
-                    _ => $name::NONE,
+                    (_, 'a'..='z') | (_, 'A'..='Z') => $name::INVALID,
+                    _ => $name::RESET,
                 }
             }
         }
@@ -32,31 +34,31 @@ macro_rules! schemes {
 
 schemes! {
     SchemeState {
-        [NONE, 'h'|'H' => H],
+        [RESET, 'h'|'H' => H],
         [H, 't'|'T' => HT],
         [HT, 't'|'T' => HTT],
         [HTT, 'p'|'P' => HTTP],
         [HTTP, 's'|'S' => HTTPS],
-        [NONE, 'f'|'F' => F],
+        [RESET, 'f'|'F' => F],
         [F, 't'|'T' => FT],
         [FT, 'p'|'P' => FTP],
         [F, 'i'|'I' => FI],
         [FI, 'l'|'L' => FIL],
         [FIL, 'e'|'E' => FILE],
-        [NONE, 'm'|'M' => M],
+        [RESET, 'm'|'M' => M],
         [M, 'a'|'A' => MA],
         [MA, 'i'|'I' => MAI],
         [MAI, 'l'|'L' => MAIL],
         [MAIL, 't'|'T' => MAILT],
         [MAILT, 'o'|'O' => MAILTO],
-        [NONE, 'n'|'N' => N],
+        [RESET, 'n'|'N' => N],
         [N, 'e'|'E' => NE],
         [NE, 'w'|'W' => NEW],
         [NEW, 's'|'S' => NEWS],
-        [NONE, 'g'|'G' => G],
+        [RESET, 'g'|'G' => G],
         [G, 'i'|'I' => GI],
         [GI, 't'|'T' => GIT],
-        [NONE, 's'|'S' => S],
+        [RESET, 's'|'S' => S],
         [S, 's'|'S' => SS],
         [SS, 'h'|'H' => SSH],
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,8 +4,15 @@ use crate::{SchemeState, UrlLocation, UrlLocator};
 
 #[test]
 fn advance_schemes() {
-    let state = SchemeState::NONE;
-    assert_eq!(state, SchemeState::NONE);
+    let state = SchemeState::RESET;
+
+    let state = state.advance('h');
+    assert_eq!(state, SchemeState::H);
+    let state = state.advance('x');
+    assert_eq!(state, SchemeState::INVALID);
+    let state = state.advance(' ');
+    assert_eq!(state, SchemeState::RESET);
+
     let state = state.advance('h');
     assert_eq!(state, SchemeState::H);
     let state = state.advance('t');
@@ -63,6 +70,7 @@ fn url_unicode() {
 #[test]
 fn url_schemes() {
     assert_eq!(max_len("invalidscheme://example.org"), None);
+    assert_eq!(max_len("makefile://example.org"), None);
     assert_eq!(max_len("mailto://example.org"), Some(20));
     assert_eq!(max_len("https://example.org"), Some(19));
     assert_eq!(max_len("http://example.org"), Some(18));
@@ -152,9 +160,8 @@ fn parser_states() {
     result_map.insert(9, UrlLocation::Url(7, 0));
     result_map.insert(21, UrlLocation::Url(19, 0));
     result_map.insert(22, UrlLocation::Reset);
-    result_map.insert(24, UrlLocation::Reset);
-    result_map.insert(25, UrlLocation::Scheme);
-    result_map.insert(26, UrlLocation::Reset);
+    result_map.insert(24, UrlLocation::Scheme);
+    result_map.insert(27, UrlLocation::Reset);
     exact_url_match(input, result_map);
 }
 


### PR DESCRIPTION
This resolves an error where URLs would be found in text, without clear
separation between the text and the start of the scheme, like
`Makefile:13`.

Fixes #4.